### PR TITLE
Async warning cleanup

### DIFF
--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -40,7 +40,7 @@ pub mod refresh {
                         .map_err(|()| Error::Primitive)?;
                     Input::Recovered {
                         scope: request.scope(),
-                        grant: Box::new(recovered),
+                        grant: recovered.map(|r| Box::new(r)),
                     }
                 }
                 Requested::Authenticate { client, pass } => {
@@ -224,7 +224,7 @@ pub mod access_token {
                             extensions: None,
                         }))
                     })?;
-                    Input::Recovered(Box::new(opt_grant))
+                    Input::Recovered(opt_grant.map(|o| Box::new(o)))
                 }
                 Requested::Extend { extensions } => {
                     let access_extensions = handler

--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -46,7 +46,7 @@ pub mod refresh {
                 Requested::Authenticate { client, pass } => {
                     let _: () = handler
                         .registrar()
-                        .check(&client, pass.as_ref().map(|p| p.as_slice()))
+                        .check(&client, pass.as_deref())
                         .await
                         .map_err(|err| match err {
                             RegistrarError::PrimitiveError => Error::Primitive,

--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -39,7 +39,7 @@ pub mod refresh {
                         .await
                         .map_err(|()| Error::Primitive)?;
                     Input::Recovered {
-                        request,
+                        scope: request.scope(),
                         grant: Box::new(recovered),
                     }
                 }
@@ -52,7 +52,9 @@ pub mod refresh {
                             RegistrarError::PrimitiveError => Error::Primitive,
                             RegistrarError::Unspecified => Error::unauthorized("basic"),
                         })?;
-                    Input::Authenticated { request }
+                    Input::Authenticated {
+                        scope: request.scope(),
+                    }
                 }
             };
 

--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -186,7 +186,6 @@ pub mod access_token {
             },
             Recover(&'a str),
             Extend {
-                grant: &'a Grant,
                 extensions: &'a mut Extensions,
             },
             Issue {
@@ -223,7 +222,7 @@ pub mod access_token {
                     })?;
                     Input::Recovered(opt_grant)
                 }
-                Requested::Extend { grant: _, extensions } => {
+                Requested::Extend { extensions } => {
                     let access_extensions = handler
                         .extension()
                         .extend(request, extensions.clone())
@@ -249,7 +248,7 @@ pub mod access_token {
                     Requested::Authenticate { client, passdata }
                 }
                 Output::Recover { code } => Requested::Recover(code),
-                Output::Extend { grant, extensions } => Requested::Extend { grant, extensions },
+                Output::Extend { extensions, .. } => Requested::Extend { extensions },
                 Output::Issue { grant } => Requested::Issue { grant },
                 Output::Ok(token) => return Ok(token),
                 Output::Err(e) => return Err(e),

--- a/oxide-auth/src/code_grant/authorization.rs
+++ b/oxide-auth/src/code_grant/authorization.rs
@@ -337,7 +337,7 @@ pub fn authorization_code(handler: &mut dyn Endpoint, request: &dyn Request) -> 
             } => {
                 let client_url = ClientUrl {
                     client_id: Cow::Owned(client_id),
-                    redirect_uri: redirect_uri.map(|uri| Cow::Owned(uri)),
+                    redirect_uri: redirect_uri.map(Cow::Owned),
                 };
                 let bound_client = match handler.registrar().bound_redirect(client_url) {
                     Err(RegistrarError::Unspecified) => return Err(Error::Ignore),
@@ -530,7 +530,7 @@ impl ErrorUrl {
     ) -> ErrorUrl {
         let mut err = ErrorUrl::new(
             redirect_uri,
-            request.state().as_deref().clone(),
+            request.state().as_deref(),
             AuthorizationError::default(),
         );
         err.description().set_type(err_type);

--- a/oxide-auth/src/code_grant/refresh.rs
+++ b/oxide-auth/src/code_grant/refresh.rs
@@ -353,13 +353,14 @@ pub fn refresh(handler: &mut dyn Endpoint, request: &dyn Request) -> Result<Bear
                 }
             }
             Requested::Authenticate { client, pass } => {
-                let _: () = handler
-                    .registrar()
-                    .check(&client, pass.as_ref().map(|p| p.as_slice()))
-                    .map_err(|err| match err {
-                        RegistrarError::PrimitiveError => Error::Primitive,
-                        RegistrarError::Unspecified => Error::unauthorized("basic"),
-                    })?;
+                let _: () =
+                    handler
+                        .registrar()
+                        .check(&client, pass.as_deref())
+                        .map_err(|err| match err {
+                            RegistrarError::PrimitiveError => Error::Primitive,
+                            RegistrarError::Unspecified => Error::unauthorized("basic"),
+                        })?;
                 Input::Authenticated { request }
             }
         };

--- a/oxide-auth/src/code_grant/resource.rs
+++ b/oxide-auth/src/code_grant/resource.rs
@@ -287,7 +287,7 @@ fn get_scopes<'req>(token: String, scopes: &'req [Scope]) -> ResourceState {
     }
 }
 
-fn recovered<'req>(grant: Option<Grant>, mut scopes: Vec<Scope>) -> Result<Grant> {
+fn recovered(grant: Option<Grant>, mut scopes: Vec<Scope>) -> Result<Grant> {
     let grant = match grant {
         Some(grant) => grant,
         None => {

--- a/oxide-auth/src/code_grant/resource.rs
+++ b/oxide-auth/src/code_grant/resource.rs
@@ -250,7 +250,7 @@ pub fn protect(handler: &mut dyn Endpoint, req: &dyn Request) -> Result<Grant> {
     }
 }
 
-fn validate<'req>(request: &'req dyn Request) -> Result<ResourceState> {
+fn validate(request: &'_ dyn Request) -> Result<ResourceState> {
     if !request.valid() {
         return Err(Error::InvalidRequest {
             authenticate: Authenticate::empty(),
@@ -280,7 +280,7 @@ fn validate<'req>(request: &'req dyn Request) -> Result<ResourceState> {
     Ok(ResourceState::Internalized { token })
 }
 
-fn get_scopes<'req>(token: String, scopes: &'req [Scope]) -> ResourceState {
+fn get_scopes(token: String, scopes: &'_ [Scope]) -> ResourceState {
     ResourceState::Recovering {
         token,
         scopes: scopes.to_owned(),

--- a/oxide-auth/src/endpoint/resource.rs
+++ b/oxide-auth/src/endpoint/resource.rs
@@ -154,6 +154,6 @@ impl<R: WebRequest> ResourceRequest for WrappedRequest<R> {
     }
 
     fn token(&self) -> Option<Cow<str>> {
-        self.authorization.as_ref().map(String::as_str).map(Cow::Borrowed)
+        self.authorization.as_deref().map(Cow::Borrowed)
     }
 }

--- a/oxide-auth/src/primitives/generator.rs
+++ b/oxide-auth/src/primitives/generator.rs
@@ -64,7 +64,7 @@ impl RandomGenerator {
 
     fn generate(&self) -> String {
         let mut result = vec![0; self.len];
-        let mut rnd = self.random.clone();
+        let mut rnd = self.random;
         rnd.try_fill_bytes(result.as_mut_slice())
             .expect("Failed to generate random token");
         encode(&result)

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -324,7 +324,7 @@ impl PasswordPolicy for Argon2 {
 //                             Standard Implementations of Registrars                            //
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-static DEFAULT_PASSWORD_POLICY: Lazy<Argon2> = Lazy::new(|| Argon2::default());
+static DEFAULT_PASSWORD_POLICY: Lazy<Argon2> = Lazy::new(Argon2::default);
 
 impl ClientMap {
     /// Create an empty map without any clients in it.


### PR DESCRIPTION
I've fixed most of the clippy's warnings and I'm left with 2 that I don't think we should bother with:
```
warning: you should consider adding a `Default` implementation for `code_grant::resource::Resource`
   --> oxide-auth\src\code_grant\resource.rs:178:5
    |
178 | /     pub fn new() -> Self {
179 | |         Resource {
180 | |             state: ResourceState::New,
181 | |         }
182 | |     }
    | |_____^
    |
    = note: `#[warn(clippy::new_without_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
    |
176 | impl Default for code_grant::resource::Resource {
177 |     fn default() -> Self {
178 |         Self::new()
179 |     }
180 | }
    |

warning: you seem to be trying to match on a boolean expression
   --> oxide-auth\src\primitives\registrar.rs:316:9
    |
316 | /         match valid {
317 | |             true => Ok(()),
318 | |             false => Err(RegistrarError::Unspecified), 
319 | |         }
    | |_________^ help: consider using an `if`/`else` expression: `if valid { Ok(()) } else { Err(RegistrarError::Unspecified) }`
    |
    = note: `#[warn(clippy::match_bool)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_bool   

```