### PR TITLE
Test the Send'ability of futures

### DIFF
--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -227,6 +227,7 @@ pub mod defaults {
 
 mod authorization;
 mod access_token;
+mod type_properties;
 mod resource;
 mod refresh;
 // mod pkce;

--- a/oxide-auth-async/src/tests/type_properties.rs
+++ b/oxide-auth-async/src/tests/type_properties.rs
@@ -1,0 +1,14 @@
+use crate::code_grant;
+
+#[test]
+fn require_futures_have_send_bounds() {
+    fn require_send<T: Send, A, B, F: FnOnce(A, B) -> T>(_: F) {}
+
+    require_send(code_grant::access_token::access_token);
+    require_send(code_grant::authorization::authorization_code);
+    require_send(|pending, handler| {
+        code_grant::authorization::Pending::authorize(pending, handler, "".into())
+    });
+    require_send(code_grant::refresh::refresh);
+    require_send(code_grant::resource::protect);
+}


### PR DESCRIPTION
This adds the test suite I've alluded to in the review https://github.com/HeroicKatora/oxide-auth/pull/105#pullrequestreview-475653236 (Note: it currently fails)

 - [x] This change has tests

[Contributing]: CONTRIBUTING.md
